### PR TITLE
Add destinations keystores migrator

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sap-btp-neo-migration",
   "version": "1.0.0",
-  "description": "SAP BTP Neo to Cloud Foundry migration skills. Includes orchestrators for end-to-end app migration and complete subaccount configuration migration, individual skills for Jakarta EE, XSUAA authentication, destinations, connectivity, HANA persistence, document management, credential store, TomEE runtime, MTA deployment, and Neo subaccount configuration export and import (trust, destinations, roles).",
+  "description": "SAP BTP Neo to Cloud Foundry migration skills. Includes orchestrators for end-to-end app migration and complete subaccount configuration migration, individual skills for Jakarta EE, XSUAA authentication, destinations, connectivity, HANA persistence, document management, credential store, TomEE runtime, MTA deployment, Neo subaccount configuration export and import (trust, destinations, roles), and neo-destinations-keystores-migrator for direct in-memory migration of destinations and keystores from Neo to CF.",
   "skills": "../ai-migration/neo-java-migration-skills/skills",
   "license": "Apache-2.0",
   "keywords": [
@@ -19,6 +19,7 @@
     "idp",
     "saml",
     "destinations",
+    "keystores",
     "roles",
     "authorization"
   ]

--- a/ai-migration/README.md
+++ b/ai-migration/README.md
@@ -36,7 +36,7 @@ claude
 /skills
 ```
 
-You should see all 22 skills listed under the `sap-btp-neo-migration` plugin.
+You should see all 23 skills listed under the `sap-btp-neo-migration` plugin.
 
 #### Update
 
@@ -169,15 +169,19 @@ Use the jakarta-java25-migration skill to upgrade to Java 25
 
 - **[tomee-runtime](skills/tomee-runtime/SKILL.md)** - TomEE container for EJB applications
 
+### 📦 Subaccount Migration Skills
+
+- **[neo-destinations-keystores-migrator](skills/neo-destinations-keystores-migrator/SKILL.md)** - End-to-end migration of destinations & keystores from Neo to CF
+
 ## Plugin Structure
 
 ```
 .claude-plugin/
 ├── marketplace.json            # Marketplace manifest
-├── plugin.json                 # Plugin manifest
+└── plugin.json                 # Plugin manifest
 
 ai-migration/
-├── neo-java-migration-skills/
+└── neo-java-migration-skills/
     ├── skills/                 # All migration skills
     │   ├── approuter-setup/
     │   ├── authentication-xsuaa/
@@ -192,6 +196,7 @@ ai-migration/
     │   ├── mail-destinations/
     │   ├── monitoring-logging/
     │   ├── mta-descriptor/
+    │   ├── neo-destinations-keystores-migrator/
     │   ├── neo-to-cf-migration-orchestrator/
     │   ├── persistence-hana/
     │   ├── sdk-replacement/
@@ -200,15 +205,15 @@ ai-migration/
     │   ├── subaccount-roles-import/
     │   ├── subaccount-trust-export/
     │   ├── subaccount-trust-import/
-    │   ├── tomee-runtime/
+    │   └── tomee-runtime/
     │
-    ├── marketplace/
-        ├── description.md
+    └── marketplace/
+        └── description.md
 ```
 
 ## Skill Discovery
 
-Once installed, Claude Code automatically discovers all 22 skills via their SKILL.md frontmatter metadata. Skills can be invoked by:
+Once installed, Claude Code automatically discovers all 23 skills via their SKILL.md frontmatter metadata. Skills can be invoked by:
 
 - **Name**: "authentication-xsuaa"
 - **Keywords**: "XSUAA", "authentication", "OAuth"

--- a/ai-migration/README.md
+++ b/ai-migration/README.md
@@ -152,6 +152,10 @@ Use the jakarta-java25-migration skill to upgrade to Java 25
 - **[destinations](skills/destinations/SKILL.md)** - Destination service for external connections
 - **[connectivity-onpremise](skills/connectivity-onpremise/SKILL.md)** - On-premise connectivity via Cloud Connector
 
+### 📦 Subaccount Migration Skills
+
+- **[neo-destinations-keystores-migrator](skills/neo-destinations-keystores-migrator/SKILL.md)** - End-to-end migration of destinations & keystores from Neo to CF
+
 ### 💾 Data Skills
 
 - **[persistence-hana](skills/persistence-hana/SKILL.md)** - HANA Cloud database binding
@@ -169,19 +173,15 @@ Use the jakarta-java25-migration skill to upgrade to Java 25
 
 - **[tomee-runtime](skills/tomee-runtime/SKILL.md)** - TomEE container for EJB applications
 
-### 📦 Subaccount Migration Skills
-
-- **[neo-destinations-keystores-migrator](skills/neo-destinations-keystores-migrator/SKILL.md)** - End-to-end migration of destinations & keystores from Neo to CF
-
 ## Plugin Structure
 
 ```
 .claude-plugin/
 ├── marketplace.json            # Marketplace manifest
-└── plugin.json                 # Plugin manifest
+├── plugin.json                 # Plugin manifest
 
 ai-migration/
-└── neo-java-migration-skills/
+├── neo-java-migration-skills/
     ├── skills/                 # All migration skills
     │   ├── approuter-setup/
     │   ├── authentication-xsuaa/
@@ -205,10 +205,10 @@ ai-migration/
     │   ├── subaccount-roles-import/
     │   ├── subaccount-trust-export/
     │   ├── subaccount-trust-import/
-    │   └── tomee-runtime/
+    │   ├── tomee-runtime/
     │
-    └── marketplace/
-        └── description.md
+    ├── marketplace/
+        ├── description.md
 ```
 
 ## Skill Discovery

--- a/ai-migration/neo-java-migration-skills/marketplace/description.md
+++ b/ai-migration/neo-java-migration-skills/marketplace/description.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Comprehensive Claude Code plugin for migrating SAP BTP Neo Java applications to Cloud Foundry. Contains 22 modular, AI-powered migration skills that handle everything from Java 25/Jakarta EE upgrades to authentication, database connectivity, and service integration.
+Comprehensive Claude Code plugin for migrating SAP BTP Neo Java applications to Cloud Foundry. Contains 23 modular, AI-powered migration skills that handle everything from Java 25/Jakarta EE upgrades to authentication, database connectivity, and service integration.
 
 ## What's Included
 
@@ -40,7 +40,7 @@ Comprehensive Claude Code plugin for migrating SAP BTP Neo Java applications to 
 
 ## Key Features
 
-✅ **22 Modular Skills** - Use individually or orchestrated together
+✅ **23 Modular Skills** - Use individually or orchestrated together
 ✅ **Agent Skills Standard** - Follows agentskills.io specification
 ✅ **Progressive Disclosure** - Efficient context usage
 ✅ **Automatic Detection** - Identifies required services from code

--- a/ai-migration/neo-java-migration-skills/skills/neo-destinations-keystores-migrator/SKILL.md
+++ b/ai-migration/neo-java-migration-skills/skills/neo-destinations-keystores-migrator/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: neo-destinations-keystores-migrator
+description: Invoke this skill to migrate destination and keystore DATA (configuration entries, certificates, credentials) that are stored at subaccount level or app level in a SAP BTP Neo environment to Cloud Foundry — this transfers platform-level configuration, NOT application source code. Use when the user wants to transfer existing Neo destination configurations or keystore entries to CF (e.g. 'migrate my BTP destinations to CF', 'copy Neo keystores to Cloud Foundry', 'transfer destination configs from Neo account', 'upload keystores to CF'). Do NOT invoke for source code changes that replace ConnectivityConfiguration/DestinationConfiguration Java API usage with SAP Cloud SDK — use the destinations skill for that instead.
+disable-model-invocation: false
+allowed-tools: Bash(curl *), Bash(python3 *), Bash(cf *)
+---
+
+# Neo Destinations and Keystores Migrator
+
+Migrates all destinations and keystores from SAP BTP Neo to Cloud Foundry in a single pass. No intermediate files are written — data flows directly from Neo APIs to CF Destination Service in memory.
+
+## Clarification — confirm the right skill before starting
+
+If the user's request is ambiguous (e.g. "migrate my destinations", "migrate destinations to CF" with no further context), ask this question **before doing anything else**:
+
+> **Which type of destinations migration do you need?**
+>
+> **A — Transfer destination configurations** stored in your Neo subaccount (names, URLs, auth types, properties) to the CF Destination Service. This does NOT touch your Java source code.
+>
+> **B — Migrate application source code** that uses the Neo Connectivity/Destination Java API (`ConnectivityConfiguration`, `DestinationConfiguration` JNDI lookups) to use SAP Cloud SDK `DestinationAccessor` instead.
+>
+> Reply **A** or **B**.
+
+- If the user replies **A** (or the request is clearly about transferring subaccount-level configs) → continue with this skill.
+- If the user replies **B** (or the request is clearly about changing Java source code) → stop and tell the user: *"For source code migration, use the **destinations** skill instead."*
+
+## What this skill does
+
+1. Fetches all Neo applications
+2. Reads account-level and app-level destinations and keystores from Neo (held in memory)
+3. Creates CF Destination Service instances as needed
+4. Uploads everything directly to CF — data never touches disk
+
+## Security disclaimers
+
+**Present the two disclaimers strictly one at a time, in order, BEFORE asking the user for any inputs. Do NOT show the next disclaimer until the user has explicitly replied to the current one. Do NOT proceed until both have been acknowledged.**
+
+### 1. Credentials — two-part disclaimer
+
+**Part A — information only, no reply needed:**
+
+Present this message first, without waiting for a reply:
+
+> **Credentials will not be migrated.**
+> For destinations that contain credentials, the Neo API does not allow them to be extracted — they will be created in CF without credentials and you will need to re-enter them manually in BTP Cockpit after migration.
+> The only exceptions are the two authentication types described below.
+
+**Part B — explicit consent required:**
+
+Immediately after Part A, present this and wait for the user to reply:
+
+> **Two destination authentication types have credentials that can be extracted from Neo:**
+> - `OAuth2SAMLBearerAssertion` with mTLS token retrieval
+> - `OAuth2ClientCredentials` with mTLS token retrieval
+>
+> Unlike other destination authentication types, the credentials for these can be extracted from Neo and uploaded to CF. However, there is a risk that they may reach this LLM model during the process.
+>
+> If your subaccount and/or applications contain destinations of these two authentication types, do you want to migrate them including their credentials?
+> - **yes** — extract and upload credentials (I accept the risk)
+> - **no** — skip these destinations entirely (they will be listed in the summary for manual handling)
+
+**Do not show disclaimer 2 until the user has replied.** Based on the reply:
+- **yes** → `MIGRATE_OAUTH_CREDENTIALS=true`
+- **no** → `MIGRATE_OAUTH_CREDENTIALS=false`
+
+### 2. Keystores — explicit consent required
+
+Present this disclaimer regardless of the answer to disclaimer 1:
+
+> **Keystores contain sensitive data.**
+> Keystores contain sensitive cryptographic information such as private keys. There is a risk that they may reach this LLM model during the process.
+>
+> Do you want to migrate keystores? (yes/no)
+
+**Do not run the migration script until the user has replied.** Based on the reply:
+- **yes** → `MIGRATE_KEYSTORES=true`
+- **no** → `MIGRATE_KEYSTORES=false`
+
+## Inputs Required
+
+After both disclaimers are acknowledged, ask the user for the required inputs:
+
+| Input | Description | Example |
+|-------|-------------|---------|
+| `TOKEN` | Neo Platform API token (valid 25 min) | `eyJhbGci...` |
+| `HOST` | Neo landscape host | `hana.ondemand.com` |
+| `ACCOUNT` | Neo subaccount technical name | `wu44p26apd` |
+
+### How to obtain a Platform API token
+
+**Step 1 — Register a Platform API client**
+
+1. Open **SAP BTP Cockpit** → navigate to the Neo subaccount
+2. Go to **Security → OAuth → Platform API** tab
+3. Click **Register New Platform Client**
+4. Select exactly these three scopes (no more, no less):
+   - **Lifecycle Management** → Read Applications
+   - **Keystore** → Read Keystores
+   - **Configuration Service** → Read Destination
+5. Note the generated **Client ID** and **Client Secret**
+
+**Step 2 — Request a token**
+
+Getting a token is a 3-step process:
+
+Always present all three options below to the user:
+
+---
+
+**Option A — Mac / Linux / WSL / Git Bash:**
+```bash
+CREDENTIALS=$(echo -n "<client_id>:<client_secret>" | base64) && \
+curl -s -X POST "https://oauthasservices.<landscape>/oauth2/apitoken/v1?grant_type=client_credentials" -H "Authorization: Basic ${CREDENTIALS}"
+```
+
+**Option B — Windows PowerShell:**
+```powershell
+# 1. Encode credentials
+$credentials = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("<client_id>:<client_secret>"))
+
+# 2. Request token
+$response = Invoke-WebRequest -Method POST "https://oauthasservices.<landscape>/oauth2/apitoken/v1?grant_type=client_credentials" -Headers @{"Authorization" = "Basic $credentials"}
+
+# 3. Extract access token
+($response.Content | ConvertFrom-Json).access_token
+```
+
+**Option C — REST client (Bruno, Postman, Insomnia, etc.):**
+
+| Field | Value |
+|-------|-------|
+| Method | `POST` |
+| URL | `https://oauthasservices.<landscape>/oauth2/apitoken/v1?grant_type=client_credentials` |
+| Auth type | Basic Auth |
+| Username | `<client_id>` |
+| Password | `<client_secret>` |
+
+Send the request and copy the `access_token` from the response.
+
+---
+
+**Step 3 — Copy the token**
+
+From the JSON response, copy the value of `access_token`. The token is valid for **25 minutes**.
+
+Required scopes — **exactly and only these three**:
+
+| API Name | Scope | Technical Name |
+|----------|-------|----------------|
+| Keystore | Read Keystores | `hcp.readKeystores` |
+| Configuration Service | Read Destination | `hcp.readDestination` |
+| Lifecycle Management | Read Applications | `hcp.readJavaApplications` |
+
+> **Critical: The Platform API client must be registered with exactly these three scopes — no more, no less.**
+>
+> The migration script validates the token's scope list at startup and **will refuse to run** if:
+> - Any of the three scopes is missing (`ERROR: Token is missing required scopes: ...`)
+> - Any additional scope is present (`ERROR: Token has scopes beyond the required set: ...`)
+>
+> If the token was issued for a client that has extra scopes (e.g. `hcp.manage*` or `hcp.write*`), you must **register a new, separate Platform API client** with exactly the three scopes above, generate a new token from that client, and use that token.
+
+### Verify CF target
+
+Run `cf target` and show the output to the user. Confirm the correct org and space before continuing.
+
+## Collect Neo → CF app mapping
+
+After both disclaimers are acknowledged and all required inputs have been collected (TOKEN, HOST, ACCOUNT), fetch the Neo app list:
+
+```bash
+curl -sk "https://api.${HOST}/lifecycle/v1/accounts/${ACCOUNT}/apps" \
+  -H "Authorization: Bearer ${TOKEN}"
+```
+Extract `entity.applicationName` from each item in the `apps` array. Follow `nextUrl` for pagination.
+
+**Auto-match by name:** Compare the Neo app names against the CF app names (from `cf apps`). For any Neo app whose name exactly matches a CF app name, pre-fill that mapping and ask the user to confirm in a single question, e.g.:
+
+> The following Neo apps have a CF app with the same name. Should I map them automatically?
+>
+>   example → example
+>   neoauthnauthzdemo2 → neoauthnauthzdemo2
+>
+> Confirm? (yes/no)
+
+Only ask about unmapped apps individually. Present like this:
+
+```
+Found N Neo apps. For each, which CF app should receive its destinations?
+(Run `cf apps` to see available CF apps. Type "skip" to skip a Neo app.)
+
+  <neo-app1> → ?   (no matching CF app found)
+  <neo-app2> → ?
+```
+
+**Do not run the migration script until the user has confirmed all mappings.**
+
+## Migration
+
+Once all inputs are confirmed, tell the user: "Running the migration script..." and then run:
+
+```bash
+TOKEN="${TOKEN}" HOST="${HOST}" ACCOUNT="${ACCOUNT}" \
+  APP_MAPPING='{"<neo-app1>": "<cf-app1>", "<neo-app2>": "<cf-app1>"}' \
+  MIGRATE_KEYSTORES="<true|false>" \
+  MIGRATE_OAUTH_CREDENTIALS="<true|false>" \
+  python3 assets/scripts/migrate_destinations_and_keystores.py
+```
+
+Do NOT show the full command to the user — only the short status message above.
+
+> **Note:** No files are written to disk. All Neo data is fetched into memory and posted directly to CF. The user's credentials and destination content are never stored locally.
+
+## What gets migrated
+
+| Neo Level | Item | CF Target |
+|-----------|------|-----------|
+| Account | Destinations | `subaccountDestinations` (instance: `<account>-account-destinations`, overridable via `ACCOUNT_INSTANCE_NAME`) |
+| Account | Keystores | `subaccountCertificates` (same instance) |
+| App | Destinations | `instanceDestinations` (per-app instance: `<neo-app>-destination`) |
+| App | Keystores | `instanceCertificates` (same per-app instance) |
+
+### Authentication type mapping
+
+| Neo | CF | Notes |
+|-----|----|-------|
+| `NoAuthentication` | `NoAuthentication` | Direct copy |
+| `BasicAuthentication` | `BasicAuthentication` | Credentials not migrated — re-enter manually in BTP Cockpit |
+| `OAuth2ClientCredentials` | `OAuth2ClientCredentials` | Credentials not migrated unless mTLS token retrieval (`tokenService.KeyStorePassword`) is present and user consented — see security disclaimer above |
+| `AppToAppSSO` | `OAuth2UserTokenExchange` | Auth type changed + credentials injected |
+| `ClientCertificateAuthentication` | `ClientCertificateAuthentication` | Direct copy |
+| `PrincipalPropagation` | `PrincipalPropagation` | Direct copy (requires Cloud Connector) |
+| `InternalSystemAuthentication` | — | Neo-specific — skipped automatically, review manually |
+
+## After migration
+
+Present a summary:
+
+```
+=== Migration Summary ===
+Account destinations : N uploaded, N skipped (InternalSystem)
+Account keystores    : N uploaded
+Apps migrated        : N
+  <neo-app> → <cf-app> (<instance-name>)
+    Destinations: N uploaded, N skipped
+    Keystores   : N uploaded
+
+Manual review required:
+  - InternalSystemAuthentication destinations: N — no CF equivalent, handle manually
+```
+
+## Common Issues
+
+### Token expired mid-run
+The Platform API token is valid for 25 minutes. If it expires, ask the user for a fresh token and re-run. The script is idempotent — already-uploaded items return HTTP 409 and are skipped.
+
+### `cf create-service` quota exceeded
+The CF space may have a limit on Destination Service instances. Check with `cf marketplace -e destination`.
+
+### CF app not found in mapping
+Run `cf apps` to list available apps. The target CF app must exist before the script can bind a Destination Service instance to it.
+
+### No account-level items
+Normal — not all Neo subaccounts have account-level destinations. The script skips the account-level CF instance creation in that case.
+
+### Destination Service instance stuck in `create in progress`
+If a previous run was interrupted mid-way, a Destination Service instance may be left in a non-terminal state. In this case the script will skip `cf create-service` (the instance already exists) but immediately attempt to create a service key, which will fail with a confusing error. To recover, wait for the instance to reach a terminal state (`cf service <instance-name>`), or delete it manually (`cf delete-service <instance-name> -f`) and re-run.

--- a/ai-migration/neo-java-migration-skills/skills/neo-destinations-keystores-migrator/assets/scripts/migrate_destinations_and_keystores.py
+++ b/ai-migration/neo-java-migration-skills/skills/neo-destinations-keystores-migrator/assets/scripts/migrate_destinations_and_keystores.py
@@ -1,0 +1,575 @@
+"""
+Migrate destinations and keystores directly from SAP BTP Neo to Cloud Foundry.
+
+Data is never written to disk — all Neo items are held in memory and uploaded
+to CF in the same process. No intermediate files are created.
+
+Usage:
+  TOKEN=<neo-platform-api-token>
+  HOST=<landscape>               e.g. hana.ondemand.com
+  ACCOUNT=<neo-subaccount>
+  APP_MAPPING=<json>             e.g. '{"neo-app1": "cf-app1", "neo-app2": "cf-app1"}'
+
+Optional overrides:
+  KEYSTORE_BASE   override https://api.<HOST>/keystore/v1
+  CONFIG_BASE     override https://configapi.<HOST>/configuration/api/rest/oauth/SPACES/<ACCOUNT>
+  WORKERS         thread count for parallel app processing (default: 20)
+"""
+import os, json, re, base64, subprocess, time, sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+REQUIRED_SCOPES = {"hcp.readKeystores", "hcp.readDestination", "hcp.readJavaApplications"}
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+NEO_TOKEN = os.environ["TOKEN"].strip()
+
+# Validate token scopes — must be exactly the three required scopes, no more, no less.
+try:
+    _payload = json.loads(base64.b64decode(NEO_TOKEN.split(".")[1] + "==").decode("utf-8"))
+    _sub = _payload.get("sub", {})
+    if isinstance(_sub, dict):
+        _token_scopes = set(_sub.get("scopes", []))
+    else:
+        _scope_val = _payload.get("scope", _payload.get("scopes", []))
+        if isinstance(_scope_val, str):
+            _token_scopes = set(_scope_val.split())
+        else:
+            _token_scopes = set(_scope_val)
+    _extra = _token_scopes - REQUIRED_SCOPES
+    _missing = REQUIRED_SCOPES - _token_scopes
+    if _missing:
+        print(f"ERROR: Token is missing required scopes: {', '.join(sorted(_missing))}\n"
+              f"Required scopes are exactly: {', '.join(sorted(REQUIRED_SCOPES))}\n"
+              f"Register a Platform API client with exactly these three scopes and generate a new token.",
+              file=sys.stderr)
+        sys.exit(1)
+    if _extra:
+        print(f"ERROR: Token has scopes beyond the required set: {', '.join(sorted(_extra))}.\n"
+              f"Required scopes are exactly: {', '.join(sorted(REQUIRED_SCOPES))}.\n"
+              f"Register a new, separate Platform API client with only these three scopes, "
+              f"generate a new token from that client, and retry.",
+              file=sys.stderr)
+        sys.exit(1)
+except (IndexError, ValueError, KeyError):
+    pass  # If token is opaque or unparseable, skip static check and let API calls fail naturally.
+HOST = os.environ.get("HOST", "").strip()
+if not HOST:
+    print("ERROR: HOST environment variable is required (e.g. hana.ondemand.com)", file=sys.stderr)
+    sys.exit(1)
+ACCOUNT = os.environ["ACCOUNT"]
+APP_MAPPING = json.loads(os.environ["APP_MAPPING"])
+WORKERS = int(os.environ.get("WORKERS", "20"))
+MIGRATE_KEYSTORES = os.environ.get("MIGRATE_KEYSTORES", "true").strip().lower() != "false"
+MIGRATE_OAUTH_CREDENTIALS = os.environ.get("MIGRATE_OAUTH_CREDENTIALS", "true").strip().lower() != "false"
+
+KEYSTORE_BASE = os.environ.get("KEYSTORE_BASE") or f"https://api.{HOST}/keystore/v1"
+CONFIG_BASE = os.environ.get("CONFIG_BASE") or \
+    f"https://configapi.{HOST}/configuration/api/rest/oauth/SPACES/{ACCOUNT}"
+
+LIFECYCLE_BASE = f"https://api.{HOST}/lifecycle/v1"
+
+# ---------------------------------------------------------------------------
+# Result tracking
+# ---------------------------------------------------------------------------
+
+class Results:
+    def __init__(self):
+        self.account_dest_ok = []
+        self.account_dest_fail = []
+        self.account_dest_skip = []
+        self.account_ks_ok = []
+        self.account_ks_fail = []
+        self.apps = {}  # app -> {dest_ok, dest_fail, dest_skip, ks_ok, ks_fail}
+
+    def app(self, name):
+        if name not in self.apps:
+            self.apps[name] = {"dest_ok": [], "dest_fail": [], "dest_skip": [], "ks_ok": [], "ks_fail": []}
+        return self.apps[name]
+
+RESULTS = Results()
+
+# ---------------------------------------------------------------------------
+# Neo API helpers
+# ---------------------------------------------------------------------------
+
+def neo_get_text(url):
+    r = subprocess.run(
+        ["curl", "-sk", "-w", "\n__STATUS__%{http_code}", url,
+         "-H", f"Authorization: Bearer {NEO_TOKEN}"],
+        capture_output=True)
+    try:
+        raw = r.stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        raise RuntimeError(f"Binary response received for text endpoint — use neo_get_binary instead (url: {url})")
+    body, _, status = raw.rpartition("\n__STATUS__")
+    status = status.strip()
+    if status == "401":
+        raise RuntimeError(f"NEO TOKEN EXPIRED (401) — provide a fresh token (url: {url})")
+    if status == "404":
+        return ""  # Resource not found — treat as empty (app/account has no items)
+    if status.startswith("4") or status.startswith("5"):
+        raise RuntimeError(f"NEO API error {status} fetching {url}")
+    return body
+
+
+def neo_get_json(url):
+    return json.loads(neo_get_text(url))
+
+
+def neo_get_binary(url):
+    """Return raw bytes from Neo API."""
+    r = subprocess.run(
+        ["curl", "-sk", "-w", "\n__STATUS__%{http_code}", url,
+         "-H", f"Authorization: Bearer {NEO_TOKEN}"],
+        capture_output=True)
+    raw = r.stdout
+    # Split off the status suffix (ASCII) from the binary body
+    marker = b"\n__STATUS__"
+    idx = raw.rfind(marker)
+    if idx == -1:
+        return raw
+    body = raw[:idx]
+    status = raw[idx + len(marker):].decode("ascii", errors="replace").strip()
+    if status == "401":
+        raise RuntimeError(f"NEO TOKEN EXPIRED (401) — provide a fresh token (url: {url})")
+    if status == "404":
+        return b""  # Resource not found — treat as empty (app/account has no items)
+    if status.startswith("4") or status.startswith("5"):
+        raise RuntimeError(f"NEO API error {status} fetching {url}")
+    return body
+
+
+def neo_get_headers(url):
+    r = subprocess.run(
+        ["curl", "-sk", "-I", url, "-H", f"Authorization: Bearer {NEO_TOKEN}"],
+        capture_output=True)
+    return r.stdout.decode("utf-8")
+
+
+def is_error_text(text):
+    low = text.lower()
+    return any(x in low for x in ["exception", "not found", "<html",
+                                    "forbidden", "description\":"])
+
+
+def parse_item_list(raw):
+    if not raw or not raw.strip() or is_error_text(raw):
+        return []
+    return [x.strip() for x in raw.strip().splitlines()
+            if x.strip() and len(x.strip()) < 256 and " " not in x.strip()
+            and not x.strip().startswith("com.sap")]
+
+
+def parse_properties(text):
+    props = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            props[key.strip()] = value.replace("\\:", ":").replace("\\/", "/").replace("\\=", "=")
+    return props
+
+
+# ---------------------------------------------------------------------------
+# CF helpers
+# ---------------------------------------------------------------------------
+
+def cf_cmd(args):
+    r = subprocess.run(["cf"] + args, capture_output=True, text=True)
+    return r.stdout + r.stderr
+
+
+def cf_get_token(token_url, client_id, client_secret):
+    r = subprocess.run([
+        "curl", "-s", "-X", "POST", token_url,
+        "-u", f"{client_id}:{client_secret}",
+        "-d", "grant_type=client_credentials"
+    ], capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout)["access_token"].strip()
+    except (json.JSONDecodeError, KeyError) as e:
+        raise RuntimeError(f"Failed to get CF token from {token_url}: {e}\n{r.stdout[:300]}")
+
+
+def cf_get_service_key_credentials(instance_name, key_name):
+    r = subprocess.run(["cf", "service-key", instance_name, key_name],
+                       capture_output=True, text=True)
+    lines = r.stdout.strip().splitlines()
+    json_start = next((i for i, l in enumerate(lines) if l.strip().startswith("{")), None)
+    if json_start is None:
+        return None, r.stdout
+    try:
+        creds = json.loads("\n".join(lines[json_start:]))["credentials"]
+    except (json.JSONDecodeError, KeyError) as e:
+        return None, f"Failed to parse service key JSON: {e}\n{r.stdout[:300]}"
+    auth_url = creds["url"].rstrip("/")
+    return {
+        "client_id": creds["clientid"],
+        "client_secret": creds["clientsecret"],
+        "token_url": auth_url + "/oauth/token",
+        "dest_api_url": creds["uri"],
+    }, None
+
+
+def cf_post(dest_api_url, token, endpoint, payload, name, ok_list, fail_list):
+    r = subprocess.run([
+        "curl", "-s", "-w", "\n%{http_code}", "-X", "POST",
+        f"{dest_api_url}{endpoint}",
+        "-H", f"Authorization: Bearer {token}",
+        "-H", "Content-Type: application/json",
+        "-d", json.dumps(payload)
+    ], capture_output=True, text=True)
+    lines = r.stdout.strip().split("\n")
+    status = lines[-1]
+    if status in ("200", "201", "207", "409"):
+        ok_list.append(name)
+    else:
+        fail_list.append(name)
+
+
+def cf_ensure_instance_and_creds(instance_name, key_name, cf_app_name=None):
+    """Create CF Destination Service instance, optionally bind a CF app, return credentials dict."""
+    out = cf_cmd(["create-service", "destination", "lite", instance_name])
+    if "already exists" not in out.lower():
+        for _ in range(12):
+            status_out = cf_cmd(["service", instance_name])
+            if "create succeeded" in status_out.lower():
+                break
+            if "create failed" in status_out.lower() or "failed to create" in status_out.lower():
+                raise RuntimeError(f"Service '{instance_name}' failed to create")
+            time.sleep(5)
+        else:
+            raise RuntimeError(f"Service '{instance_name}' did not reach 'create succeeded' within 60 s")
+
+    if cf_app_name:
+        out = cf_cmd(["bind-service", cf_app_name, instance_name])
+        if "error" in out.lower() or "failed" in out.lower() or "not found" in out.lower():
+            if "already bound" not in out.lower():
+                raise RuntimeError(f"Failed to bind '{cf_app_name}' → '{instance_name}': {out[:300]}")
+
+    cf_cmd(["create-service-key", instance_name, key_name])
+    creds, err = cf_get_service_key_credentials(instance_name, key_name)
+    if creds is None:
+        raise RuntimeError(f"Could not parse service key credentials: {err[:300]}")
+    return creds
+
+
+def cf_delete_service_key(instance_name, key_name):
+    cf_cmd(["delete-service-key", instance_name, key_name, "-f"])
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Fetch Neo application list
+# ---------------------------------------------------------------------------
+
+def has_sensitive_oauth_credentials(props):
+    """Return True if this destination carries credentials that require explicit consent."""
+    if "tokenService.KeyStorePassword" not in props:
+        return False
+    auth = props.get("Authentication", "")
+    return auth in ("OAuth2SAMLBearerAssertion", "OAuth2ClientCredentials")
+
+
+def fetch_neo_apps():
+    all_apps = []
+    url = f"{LIFECYCLE_BASE}/accounts/{ACCOUNT}/apps"
+    while url:
+        d = neo_get_json(url)
+        page_apps = d.get("apps", [])
+        all_apps.extend(page_apps)
+        next_path = d.get("nextUrl")
+        url = (next_path if next_path.startswith("http") else f"https://{HOST}{next_path}") if next_path else None
+    return list(dict.fromkeys(
+        a["entity"]["applicationName"] for a in all_apps
+        if "entity" in a and "applicationName" in a["entity"]
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Fetch account-level items from Neo (in memory)
+# ---------------------------------------------------------------------------
+
+def fetch_account_items():
+    """Return (destinations: dict[name->props], keystores: dict[name->bytes])."""
+    destinations = {}
+    keystores = {}
+
+    # Configuration API — destinations and keystores attached to destinations
+    items = parse_item_list(neo_get_text(f"{CONFIG_BASE}/connectivity/"))
+    for name in items:
+        if re.search(r'\.(jks|p12|pem|jceks)$', name, re.IGNORECASE):
+            if MIGRATE_KEYSTORES:
+                data = neo_get_binary(f"{CONFIG_BASE}/connectivity/{name}")
+                if data:
+                    keystores[name] = data
+        else:
+            content = neo_get_text(f"{CONFIG_BASE}/connectivity/{name}")
+            if is_error_text(content):
+                continue
+            props = parse_properties(content)
+            if props:
+                destinations[name] = props
+
+    # Keystore API — standalone keystores registered at account level
+    if MIGRATE_KEYSTORES:
+        try:
+            ks_data = neo_get_json(f"{KEYSTORE_BASE}/accounts/{ACCOUNT}")
+            for ks in ks_data.get("keystores", []):
+                name = ks["name"]
+                hdrs = neo_get_headers(f"{KEYSTORE_BASE}/accounts/{ACCOUNT}/{name}")
+                ext = next(
+                    (l.split(":", 1)[1].strip() for l in hdrs.splitlines()
+                     if l.lower().startswith("x-sap-keystore-type:")),
+                    "jks"
+                ).strip() or "jks"
+                data = neo_get_binary(f"{KEYSTORE_BASE}/accounts/{ACCOUNT}/{name}")
+                if data:
+                    keystores[f"{name}.{ext}"] = data
+        except Exception:
+            pass
+
+    return destinations, keystores
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Fetch app-level items from Neo (in memory, parallel)
+# ---------------------------------------------------------------------------
+
+def fetch_app_items(app):
+    """Return (destinations: dict[name->props], keystores: dict[name->bytes])."""
+    destinations = {}
+    keystores = {}
+
+    # Keystore API
+    if MIGRATE_KEYSTORES:
+        try:
+            ks_data = neo_get_json(f"{KEYSTORE_BASE}/accounts/{ACCOUNT}/apps/{app}")
+            for ks in ks_data.get("keystores", []):
+                name = ks["name"]
+                hdrs = neo_get_headers(f"{KEYSTORE_BASE}/accounts/{ACCOUNT}/apps/{app}/{name}")
+                ext = next(
+                    (l.split(":", 1)[1].strip() for l in hdrs.splitlines()
+                     if l.lower().startswith("x-sap-keystore-type:")),
+                    "jks"
+                ).strip() or "jks"
+                data = neo_get_binary(f"{KEYSTORE_BASE}/accounts/{ACCOUNT}/apps/{app}/{name}")
+                if data:
+                    keystores[f"{name}.{ext}"] = data
+        except Exception:
+            pass
+
+    # Destination API
+    items = parse_item_list(
+        neo_get_text(f"{CONFIG_BASE}/appliances/{app}/components/web/base/connectivity/"))
+    for name in items:
+        if re.search(r'\.(jks|p12|pem|jceks)$', name, re.IGNORECASE):
+            if MIGRATE_KEYSTORES:
+                data = neo_get_binary(
+                    f"{CONFIG_BASE}/appliances/{app}/components/web/base/connectivity/{name}")
+                if data:
+                    keystores[name] = data
+        else:
+            content = neo_get_text(
+                f"{CONFIG_BASE}/appliances/{app}/components/web/base/connectivity/{name}")
+            if is_error_text(content):
+                continue
+            props = parse_properties(content)
+            if props:
+                destinations[name] = props
+
+    return destinations, keystores
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Upload account-level items to CF
+# ---------------------------------------------------------------------------
+
+def upload_account_items(destinations, keystores, creds):
+    token = cf_get_token(creds["token_url"], creds["client_id"], creds["client_secret"])
+    dest_api_url = creds["dest_api_url"]
+
+    for name, props in sorted(destinations.items()):
+        if props.get("Authentication") == "InternalSystemAuthentication":
+            RESULTS.account_dest_skip.append(name)
+            continue
+        if not MIGRATE_OAUTH_CREDENTIALS and has_sensitive_oauth_credentials(props):
+            RESULTS.account_dest_skip.append(name)
+            continue
+        cf_post(dest_api_url, token, "/destination-configuration/v1/subaccountDestinations",
+                props, name, RESULTS.account_dest_ok, RESULTS.account_dest_fail)
+
+    for name, data in sorted(keystores.items()):
+        if not data:
+            RESULTS.account_ks_fail.append(name)
+            continue
+        cf_post(dest_api_url, token, "/destination-configuration/v1/subaccountCertificates",
+                {"Name": name, "Content": base64.b64encode(data).decode("utf-8")},
+                name, RESULTS.account_ks_ok, RESULTS.account_ks_fail)
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Upload app-level items to CF
+# ---------------------------------------------------------------------------
+
+def upload_app_items(app, destinations, keystores, cf_app_name):
+    """Returns True if a service key was created (caller must delete it), False otherwise."""
+    r = RESULTS.app(app)
+
+    if not destinations and not keystores:
+        return False
+
+    instance_name = f"{app}-destination"
+    key_name = f"{instance_name}-key"
+
+    try:
+        creds = cf_ensure_instance_and_creds(instance_name, key_name, cf_app_name)
+    except RuntimeError as e:
+        for name, props in destinations.items():
+            auth = props.get("Authentication", "")
+            if auth == "InternalSystemAuthentication" or (
+                    not MIGRATE_OAUTH_CREDENTIALS and has_sensitive_oauth_credentials(props)):
+                r["dest_skip"].append(name)
+            else:
+                r["dest_fail"].append(name)
+        for name in keystores:
+            r["ks_fail"].append(name)
+        return False
+
+    token = cf_get_token(creds["token_url"], creds["client_id"], creds["client_secret"])
+    dest_api_url = creds["dest_api_url"]
+
+    for name, props in sorted(destinations.items()):
+        auth = props.get("Authentication", "")
+        if auth == "InternalSystemAuthentication":
+            r["dest_skip"].append(name)
+            continue
+        if not MIGRATE_OAUTH_CREDENTIALS and has_sensitive_oauth_credentials(props):
+            r["dest_skip"].append(name)
+            continue
+        if auth == "AppToAppSSO":
+            props = dict(props)
+            props["Authentication"] = "OAuth2UserTokenExchange"
+            props["clientId"] = creds["client_id"]
+            props["clientSecret"] = creds["client_secret"]
+            props["tokenServiceURL"] = creds["token_url"]
+            props["tokenServiceURLType"] = "Dedicated"
+        cf_post(dest_api_url, token,
+                "/destination-configuration/v1/instanceDestinations",
+                props, name, r["dest_ok"], r["dest_fail"])
+
+    for name, data in sorted(keystores.items()):
+        if not data:
+            r["ks_fail"].append(name)
+            continue
+        cf_post(dest_api_url, token,
+                "/destination-configuration/v1/instanceCertificates",
+                {"Name": name, "Content": base64.b64encode(data).decode("utf-8")},
+                name, r["ks_ok"], r["ks_fail"])
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    try:
+        app_names = fetch_neo_apps()
+    except RuntimeError as e:
+        print(f"ERROR fetching Neo app list: {e}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        account_destinations, account_keystores = fetch_account_items()
+    except RuntimeError as e:
+        print(f"ERROR fetching account-level items: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    app_data = {}
+    with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+        futures = {executor.submit(fetch_app_items, app): app for app in app_names}
+        for future in as_completed(futures):
+            app = futures[future]
+            try:
+                app_data[app] = future.result()
+            except Exception as e:
+                print(f"ERROR fetching data for app '{app}': {e}", file=sys.stderr)
+                app_data[app] = ({}, {})  # treat as empty; error already printed
+
+    created_keys = []  # (instance_name, key_name) — deleted after all uploads
+
+    try:
+        # Account-level upload
+        if account_destinations or account_keystores:
+            account_instance = os.environ.get("ACCOUNT_INSTANCE_NAME") or f"{ACCOUNT}-account-destinations"
+            account_key = f"{account_instance}-key"
+            try:
+                creds = cf_ensure_instance_and_creds(account_instance, account_key, None)
+                upload_account_items(account_destinations, account_keystores, creds)
+                created_keys.append((account_instance, account_key))
+            except Exception as e:
+                for name in account_destinations:
+                    RESULTS.account_dest_fail.append(name)
+                for name in account_keystores:
+                    RESULTS.account_ks_fail.append(name)
+
+        # App-level upload
+        for app in sorted(app_data.keys()):
+            if app not in APP_MAPPING:
+                continue
+            destinations, keystores = app_data[app]
+            if destinations or keystores:
+                key_created = upload_app_items(app, destinations, keystores, APP_MAPPING[app])
+                if key_created:
+                    instance_name = f"{app}-destination"
+                    created_keys.append((instance_name, f"{instance_name}-key"))
+
+    finally:
+        # Delete all service keys — credentials are no longer needed
+        for instance_name, key_name in created_keys:
+            cf_delete_service_key(instance_name, key_name)
+
+    # Summary output
+    print("=== Migration Summary ===")
+    print(f"\nAccount level:")
+    print(f"  Destinations — OK: {len(RESULTS.account_dest_ok)}, SKIPPED: {len(RESULTS.account_dest_skip)}, FAILED: {len(RESULTS.account_dest_fail)}")
+    if RESULTS.account_dest_skip:
+        for name in RESULTS.account_dest_skip:
+            print(f"    - {name} (skipped)")
+        if not MIGRATE_OAUTH_CREDENTIALS:
+            print(f"    Note: some destinations may have been skipped because OAuth2SAMLBearerAssertion "
+                  f"and OAuth2ClientCredentials destinations with extractable credentials were not migrated.")
+    if RESULTS.account_dest_fail:
+        for name in RESULTS.account_dest_fail:
+            print(f"    - {name}")
+    print(f"  Keystores    — OK: {len(RESULTS.account_ks_ok)}, FAILED: {len(RESULTS.account_ks_fail)}")
+    if RESULTS.account_ks_fail:
+        for name in RESULTS.account_ks_fail:
+            print(f"    - {name}")
+
+    print(f"\nApplication level:")
+    for app in sorted(RESULTS.apps.keys()):
+        r = RESULTS.apps[app]
+        print(f"  {app}:")
+        print(f"    Destinations — OK: {len(r['dest_ok'])}, SKIPPED: {len(r['dest_skip'])}, FAILED: {len(r['dest_fail'])}")
+        if r["dest_skip"]:
+            for name in r["dest_skip"]:
+                print(f"      - {name} (skipped)")
+            if not MIGRATE_OAUTH_CREDENTIALS:
+                print(f"      Note: some destinations may have been skipped because OAuth2SAMLBearerAssertion "
+                      f"and OAuth2ClientCredentials destinations with extractable credentials were not migrated.")
+        if r["dest_fail"]:
+            for name in r["dest_fail"]:
+                print(f"      - {name}")
+        print(f"    Keystores    — OK: {len(r['ks_ok'])}, FAILED: {len(r['ks_fail'])}")
+        if r["ks_fail"]:
+            for name in r["ks_fail"]:
+                print(f"      - {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-migration/neo-java-migration-skills/skills/neo-to-cf-migration-orchestrator/SKILL.md
+++ b/ai-migration/neo-java-migration-skills/skills/neo-to-cf-migration-orchestrator/SKILL.md
@@ -28,8 +28,8 @@ PHASE 0: Tooling setup — once
 
 PHASE 1: Subaccount export — once (read-only, Neo side)
   subaccount-trust-export
-  subaccount-destinations-export
   subaccount-roles-export              ← export now; import deferred to Phase 5
+  (destinations are NOT exported to file — migrated directly in Phase 3 via neo-destinations-keystores-migrator)
 
 PHASE 2: Per-app code migration — repeat for each app directory
   For each app:
@@ -41,14 +41,14 @@ PHASE 2: Per-app code migration — repeat for each app directory
 
 PHASE 3: Platform import — once (CF side, before deploy)
   subaccount-trust-import
-  subaccount-destinations-import
   (roles-import is NOT here — deferred)
 
 PHASE 4: Deploy all apps — once per app
   mvn clean package -DskipTests
   cf deploy . -f
 
-PHASE 5: Post-deploy roles import — once (after ALL apps deployed)
+PHASE 5: Post-deploy — once (after ALL apps deployed)
+  neo-destinations-keystores-migrator  ← requires CF apps to exist for app-level binding
   subaccount-roles-import              ← NOW: live XSUAA appIds exist
                                           assigns role-templates + users to collections
 ```
@@ -616,8 +616,8 @@ cf deploy . -f
 ```
 
 4. **Reminder for subaccount-level steps** (if not already completed):
-   - If subaccount platform migration has not been run: invoke `subaccount-migration-orchestrator` (trust + destinations + roles export) before deploying
-   - After all apps are deployed: run `subaccount-roles-import` to assign role-templates and users to the role collections created by `authentication-xsuaa`
+   - If subaccount platform migration has not been run: invoke `subaccount-migration-orchestrator` (trust + roles export) before deploying
+   - After all apps are deployed: run `neo-destinations-keystores-migrator` to migrate destinations and keystores, then run `subaccount-roles-import` to assign role-templates and users to the role collections created by `authentication-xsuaa`
    - See the **Full Subaccount Migration Order** section above for the complete multi-app sequence
 
 ## Common Issues
@@ -649,3 +649,4 @@ cf deploy . -f
 | tomee-runtime | TomEE container | EJB annotations |
 | monitoring-logging | Cloud Logging | Optional |
 | mta-descriptor | Deployment descriptor | Always required |
+| neo-destinations-keystores-migrator | Transfer subaccount-level and app-level destination configs and keystores from Neo to CF (platform data migration, not source code) | Subaccount-level, run in Phase 5 |

--- a/ai-migration/neo-java-migration-skills/skills/subaccount-migration-orchestrator/SKILL.md
+++ b/ai-migration/neo-java-migration-skills/skills/subaccount-migration-orchestrator/SKILL.md
@@ -3,7 +3,8 @@ name: subaccount-migration-orchestrator
 description: >-
   Orchestrate complete Neo subaccount configuration migration to Cloud Foundry. Collects
   all required inputs upfront, then invokes the subaccount migration skills in sequence:
-  trust export/import, destinations export/import, and roles export/import. Produces a
+  trust export/import and roles export. Destinations and keystores migration is deferred
+  to neo-destinations-keystores-migrator (run after all CF apps are deployed). Produces a
   consolidated migration report. Use when you want a single command to migrate all
   platform-level configuration from a Neo subaccount to CF. Individual skills can also
   be invoked standalone for partial migrations.
@@ -20,12 +21,12 @@ Orchestrate complete Neo subaccount configuration migration to Cloud Foundry.
 This orchestrator collects all required inputs upfront, then invokes the subaccount migration skills in the correct sequence to migrate all platform-level configuration from a Neo subaccount to a CF subaccount:
 
 1. **Trust** — `subaccount-trust-export` → `subaccount-trust-import`
-2. **Destinations** — `subaccount-destinations-export` → `subaccount-destinations-import`
+2. **Destinations & Keystores** — `neo-destinations-keystores-migrator` (deferred — run after all CF apps are deployed)
 3. **Roles** — `subaccount-roles-export` → `subaccount-roles-import`
 
 After all skills complete, it produces a consolidated report summarizing results across all domains.
 
-> **Individual skills can be invoked standalone.** If you only need to migrate one domain (e.g., destinations only), invoke `subaccount-destinations-export` and `subaccount-destinations-import` directly — you do not need the orchestrator.
+> **Individual skills can be invoked standalone.** If you only need to migrate destinations and keystores, invoke `neo-destinations-keystores-migrator` directly — you do not need the orchestrator.
 
 > **What this orchestrator does NOT migrate:**
 > - Application source code (use `neo-to-cf-migration-orchestrator` for that)
@@ -137,26 +138,16 @@ Record results:
 
 If trust-import fails critically (BTP CLI unavailable, CF subaccount ID wrong), stop and report the error. Do not proceed to subsequent steps.
 
-## Step 2: Destinations Migration
+## Step 2: Destinations and Keystores Migration
 
-Inform the user:
-> "Step 2/3: Migrating destinations..."
+> **Deferred — run AFTER all apps are deployed to CF.**
+> App-level destinations and keystores are bound to specific CF app instances. If the CF apps do not exist yet, the migration script cannot create or bind the per-app Destination Service instances.
+>
+> After completing app code migration (`neo-to-cf-migration-orchestrator`) and deploying all apps (`cf deploy . -f`), invoke skill: **`neo-destinations-keystores-migrator`**
 
-## Step 2: Destinations Migration
+Record in the consolidated report that destinations and keystores migration is deferred. When `neo-destinations-keystores-migrator` is later run in post-deploy Phase 5, its summary output (uploaded/failed counts per account and per app) should be appended to the report manually.
 
-> **Note:** The `subaccount-destinations-export` and `subaccount-destinations-import` skills are not yet available. Destinations migration must be performed manually for now. Skip to Step 3.
-
-Record results:
-- Log: "Destinations migration: deferred — skills not yet available. Migrate destinations manually via BTP Cockpit → Connectivity → Destinations."
-
-
-After export completes, invoke skill: **`subaccount-destinations-import`**
-
-Record results:
-- Read `$MIGRATION_DIR/neo-destinations.json` — note destination count and types
-- Read `$MIGRATION_DIR/neo-destinations-import-report.json` — note uploaded/failed/manual steps
-
-If destinations-import fails, log the error in the consolidated report but **continue** to Step 3 — roles migration is independent.
+If destinations migration fails, log the error in the consolidated report but **continue** to Step 3 — roles migration is independent.
 
 ## Step 3: Roles Export
 
@@ -187,11 +178,7 @@ Read all individual reports and build a summary. Save to `$MIGRATION_DIR/subacco
     "reportFile": "<MIGRATION_DIR>/neo-trust-import-report.json"
   },
   "destinations": {
-    "status": "completed|failed|skipped",
-    "uploaded": 0,
-    "skipped": 0,
-    "failed": 0,
-    "reportFile": "<MIGRATION_DIR>/neo-destinations-import-report.json"
+    "status": "deferred — run neo-destinations-keystores-migrator after all apps are deployed"
   },
   "roles": {
     "exportStatus": "completed",
@@ -224,12 +211,8 @@ TRUST
   Third-party IdPs:    <count> [manual config required]
   Status: <completed|failed>
 
-DESTINATIONS
-  Uploaded:            <count>
-  Already configured:  <count>
-  Skipped (RFC):       <count>
-  Failed:              <count>
-  Status: <completed|failed>
+DESTINATIONS & KEYSTORES
+  ⚠ Deferred: run neo-destinations-keystores-migrator after all apps are deployed
 
 ROLES (export only — import deferred)
   Applications: <count>
@@ -255,14 +238,14 @@ ROLES:
 Full report: $MIGRATION_DIR/subaccount-migration-report.json
 Individual reports:
   Trust:        $MIGRATION_DIR/neo-trust-import-report.json
-  Destinations: $MIGRATION_DIR/neo-destinations-import-report.json
   Roles export: $MIGRATION_DIR/neo-roles.json
 
 NEXT STEPS:
   1. Complete all manual steps listed above
   2. Migrate application code: use neo-to-cf-migration-orchestrator for each app
   3. Deploy all apps to CF: cf deploy . -f (from each app directory)
-  4. Run subaccount-roles-import to assign role-templates and users
+  4. Run neo-destinations-keystores-migrator to migrate destinations and keystores
+  5. Run subaccount-roles-import to assign role-templates and users
 ```
 
 ## Configuration Files
@@ -274,8 +257,6 @@ NEXT STEPS:
 | `subaccount-migration-report.json` | `$MIGRATION_DIR` | Consolidated migration report |
 | `neo-trust-config.json` | `$MIGRATION_DIR` | Trust export output |
 | `neo-trust-import-report.json` | `$MIGRATION_DIR` | Trust import results |
-| `neo-destinations.json` | `$MIGRATION_DIR` | Destinations export output |
-| `neo-destinations-import-report.json` | `$MIGRATION_DIR` | Destinations import results |
 | `neo-roles.json` | `$MIGRATION_DIR` | Roles export output |
 | `neo-roles-import-report.json` | `$MIGRATION_DIR` | Roles import results |
 
@@ -283,7 +264,7 @@ NEXT STEPS:
 
 | Service | Plan | Purpose | Created by |
 |---------|------|---------|------------|
-| `destination` | `lite` | Subaccount-level destinations | `subaccount-destinations-import` |
+| `destination` | `lite` | Subaccount-level destinations | `neo-destinations-keystores-migrator` |
 
 ## Common Issues
 
@@ -301,7 +282,7 @@ NEXT STEPS:
 
 ### Issue: One step fails but others succeed
 **Cause:** Independent failures per domain (e.g., Destination Service not entitled but trust works fine).
-**Solution:** Fix the specific issue and re-invoke only the affected skill pair directly (e.g., `subaccount-destinations-import`). The orchestrator can also be re-run — idempotent operations will skip already-completed work.
+**Solution:** Fix the specific issue and re-invoke only the affected skill directly (e.g., `neo-destinations-keystores-migrator`). The orchestrator can also be re-run — idempotent operations will skip already-completed work.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Adds `neo-destinations-keystores-migrator` skill for direct in-memory migration of destinations and keystores from Neo to CF
- Updates skill count from 22 to 23 across README, plugin.json, and marketplace description
- Registers the skill in `neo-to-cf-migration-orchestrator` and `subaccount-migration-orchestrator`
- Updates `.hyperspace/goals/SKILLS.md` to document the new skill